### PR TITLE
Verifier fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,3 @@ results
 
 npm-debug.log
 node_modules/
-/.vscode/*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "editor.formatOnSave": false,
+  "editor.codeActionsOnSave": []
+}

--- a/src/challenges/c2-sort-the-numbers/index.ts
+++ b/src/challenges/c2-sort-the-numbers/index.ts
@@ -1,11 +1,5 @@
 import type { Challenge } from '../types.js';
 
-class ArrayNoSort extends Array {
-  public override sort() {
-    return ['allowed', 'no', 'sort'] as unknown as this;
-  }
-}
-
 const challenge: Challenge<[arr: readonly number[]], readonly number[]> = {
   title: 'Sort The Numbers',
   description:
@@ -20,9 +14,6 @@ const challenge: Challenge<[arr: readonly number[]], readonly number[]> = {
       output: [1, 1, 2, 10, 12, 16, 22, 23, 33, 34, 65, 150, 250, 300],
     },
   ],
-  context: {
-    Array: ArrayNoSort,
-  },
 };
 
 export default challenge;

--- a/src/challenges/c5-add/index.ts
+++ b/src/challenges/c5-add/index.ts
@@ -23,7 +23,7 @@ const challenge: Challenge<[input: [number, number]], number> = {
     },
   ],
   context: {
-    eval: () => 42,
+    eval: () => "eval is not the answer you're looking for",
   },
   assertRules: (playString) => {
     if (playString.includes('+')) {

--- a/src/challenges/types.ts
+++ b/src/challenges/types.ts
@@ -31,4 +31,5 @@ export interface Challenge<
   assertRules?: (playString: string) => void;
   context?: Record<string, unknown>;
   timeLimitMinutes?: number;
+  runBefore?: () => void;
 }

--- a/src/game/game-verifier.ts
+++ b/src/game/game-verifier.ts
@@ -4,8 +4,6 @@ import * as url from 'url';
 
 import type { VerifyJob } from './verifier.js';
 import * as game from './game.js';
-import { challenges } from '../challenges/index.js';
-import { Primitive } from '../challenges/types.js';
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
@@ -17,15 +15,10 @@ export const verify = (
 ) => {
   const currentGame = game.getOrError();
   const verifier = child_process.fork(path.resolve(__dirname, 'verifier.ts'));
-  const challenge = challenges.find((ch) => ch.key === currentGame.key);
 
-  if (!challenge) {
-    throw new Error('Challenge not found');
-  }
-
-  const job: VerifyJob<readonly Primitive[], Primitive> = {
+  const job: VerifyJob = {
     file,
-    challenge,
+    key: currentGame.key,
   };
 
   verifier.send(job);

--- a/src/game/utils.ts
+++ b/src/game/utils.ts
@@ -42,10 +42,6 @@ export const formatTypeAndValue = (
     return 'null';
   }
 
-  if (typeof value === 'undefined') {
-    return 'undefined';
-  }
-
   if (typeof value === 'function') {
     return `${isResult ? 'different ' : ''}function`;
   }

--- a/src/game/utils.ts
+++ b/src/game/utils.ts
@@ -34,7 +34,10 @@ export const formatValue = (value: unknown): string => {
   return `Unknown value: ${value}`;
 };
 
-export const formatTypeAndValue = (value: unknown, actual: Primitive) => {
+export const formatTypeAndValue = (
+  value: Primitive | readonly unknown[] | Record<string, unknown>,
+  actual: Primitive
+) => {
   if (value === null) {
     return 'null';
   }
@@ -44,23 +47,12 @@ export const formatTypeAndValue = (value: unknown, actual: Primitive) => {
   }
 
   if (typeof value === 'function') {
-    return 'function';
+    return `${actual ? 'different ' : ''}function`;
   }
 
   if (Array.isArray(value)) {
-    return (actual ? 'different ' : '') + 'array of ' + value.length + ' items';
+    return `${actual ? 'different ' : ''}array (${JSON.stringify(value)})`;
   }
 
-  if (typeof value === 'string') {
-    return (
-      (actual ? 'different ' : '') + 'string of ' + value.length + ' chars'
-    );
-  }
-
-  if (typeof value === 'object') {
-    return (actual ? 'different ' : '') + 'object';
-  }
-
-  const digits = value.toString().replace(/[^0-9]/g, '').length;
-  return (actual ? 'different ' : '') + `${digits} digit number`;
+  return `${actual ? 'different ' : ''}${typeof value} (${JSON.stringify(value)})`;
 };

--- a/src/game/utils.ts
+++ b/src/game/utils.ts
@@ -36,7 +36,7 @@ export const formatValue = (value: unknown): string => {
 
 export const formatTypeAndValue = (
   value: Primitive | readonly unknown[] | Record<string, unknown>,
-  actual: Primitive
+  isResult: Primitive
 ) => {
   if (value === null) {
     return 'null';
@@ -47,12 +47,12 @@ export const formatTypeAndValue = (
   }
 
   if (typeof value === 'function') {
-    return `${actual ? 'different ' : ''}function`;
+    return `${isResult ? 'different ' : ''}function`;
   }
 
   if (Array.isArray(value)) {
-    return `${actual ? 'different ' : ''}array (${JSON.stringify(value)})`;
+    return `array ${formatValue(value)}`;
   }
 
-  return `${actual ? 'different ' : ''}${typeof value} (${JSON.stringify(value)})`;
+  return `${typeof value} ${formatValue(value)}`;
 };

--- a/src/game/verifier.ts
+++ b/src/game/verifier.ts
@@ -2,7 +2,7 @@ import lodash from 'lodash';
 import { readFileSync } from 'fs';
 import { runInNewContext } from 'vm';
 
-import { formatTypeAndValue } from './utils.js';
+import { formatTypeAndValue, formatValue } from './utils.js';
 import { challenges } from '../challenges/index.js';
 import { Primitive } from '../challenges/types.js';
 
@@ -77,7 +77,7 @@ process.on('message', (entry: VerifyJob) => {
             )} but received ${formatTypeAndValue(
               result,
               true
-            )} when supplied with ${formatTypeAndValue(assertion.input, false)}`
+            )} when supplied with arguments: ${assertion.input.map((input) => formatValue(input)).join(', ')}`
           );
         }
       });

--- a/src/game/verifier.ts
+++ b/src/game/verifier.ts
@@ -89,7 +89,7 @@ process.on('message', (entry: VerifyJob) => {
             ? err
             : err instanceof Error
               ? err.message
-              : 'Unknown error',
+              : `Unknown error ${err}`,
         valid: false,
       });
     }

--- a/src/game/verifier.ts
+++ b/src/game/verifier.ts
@@ -28,7 +28,9 @@ process.on('message', (entry: VerifyJob) => {
     const context: { play?: unknown; module: { exports: unknown } } = {
       ...challenge.context,
       module: {
-        exports: {},
+        exports: {
+          runBefore: challenge.runBefore,
+        },
       },
     };
 
@@ -38,6 +40,15 @@ process.on('message', (entry: VerifyJob) => {
       '\ntry{if (!module.exports.play) {module.exports.play = play}} catch(e) {}';
 
     runInNewContext(toRun, context);
+
+    if (
+      typeof context.module.exports === 'object' &&
+      !!context.module.exports &&
+      hasKey(context.module.exports, 'runBefore') &&
+      typeof context.module.exports.runBefore === 'function'
+    ) {
+      context.module.exports.runBefore();
+    }
 
     const play =
       typeof context.module.exports === 'function'

--- a/src/game/verifier.ts
+++ b/src/game/verifier.ts
@@ -2,19 +2,13 @@ import lodash from 'lodash';
 import { readFileSync } from 'fs';
 import { runInNewContext } from 'vm';
 
-import type { Challenge, Primitive } from '../challenges/types.js';
 import { formatTypeAndValue } from './utils.js';
+import { challenges } from '../challenges/index.js';
+import { Primitive } from '../challenges/types.js';
 
-export interface VerifyJob<
-  A extends readonly Primitive[],
-  R extends Primitive,
-> {
+export interface VerifyJob {
   file: string;
-  challenge: Omit<Challenge<A, R>, 'example'> & {
-    key: string;
-    solution: string;
-    example: string;
-  };
+  key: string;
 }
 
 const hasKey = <K extends string>(
@@ -22,8 +16,14 @@ const hasKey = <K extends string>(
   key: K
 ): obj is { [P in K]: unknown } => key in obj;
 
-process.on('message', (entry: VerifyJob<readonly Primitive[], Primitive>) => {
+process.on('message', (entry: VerifyJob) => {
   try {
+    const challenge = challenges.find((ch) => ch.key === entry.key);
+
+    if (!challenge) {
+      throw new Error('Challenge not found');
+    }
+
     const script = readFileSync(entry.file, 'utf8');
     const context: { play?: unknown; module: { exports: unknown } } = {
       module: {
@@ -56,7 +56,9 @@ process.on('message', (entry: VerifyJob<readonly Primitive[], Primitive>) => {
     }
 
     try {
-      entry.challenge.assertions.forEach((assertion) => {
+      challenge.assertRules?.(script);
+
+      challenge.assertions.forEach((assertion) => {
         const result = play(...assertion.input);
 
         const expected =
@@ -79,8 +81,6 @@ process.on('message', (entry: VerifyJob<readonly Primitive[], Primitive>) => {
           );
         }
       });
-
-      entry.challenge.assertRules?.(entry.challenge.solution);
     } catch (err) {
       return process.send?.({
         err:
@@ -99,7 +99,7 @@ process.on('message', (entry: VerifyJob<readonly Primitive[], Primitive>) => {
     console.error('Verifier failed with error:', err);
 
     process.send?.({
-      err: 'Your script contains an error',
+      err: `Your script contains an error: ${err}`,
       valid: false,
     });
   }

--- a/src/game/verifier.ts
+++ b/src/game/verifier.ts
@@ -26,6 +26,7 @@ process.on('message', (entry: VerifyJob) => {
 
     const script = readFileSync(entry.file, 'utf8');
     const context: { play?: unknown; module: { exports: unknown } } = {
+      ...challenge.context,
       module: {
         exports: {},
       },


### PR DESCRIPTION
Relies on #3 

- Add config to `.vscode/settings.json` to prevent formatting on save (affects solutions)
- Do not gitignore `.vscode` directory
- Fix `assertRules` check by importing the challenges from the verifier (functions cannot be sent through the `.send` method)
- Ensure context is added to the verifier VM
- Remove unnecessary context from sort challenge
- Improved error reporting/feedback
- Added ability to define a `runBefore` function to modify globals before submissions are run